### PR TITLE
Added plugin system for schema's

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -69,6 +69,7 @@ disable=
     undefined-loop-variable,
     no-name-in-module,
     global-statement,
+    no-member,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Config Suite TUI is text-based user interface extension for [Config Suite](https
 -   Simplified editing of configuration files
 -   Import and export yaml files
 -   Instant validation
+-   Plugin system to provide schemas from other python modules
 
 ## License
 

--- a/configsuite_tui/__init__.py
+++ b/configsuite_tui/__init__.py
@@ -1,4 +1,7 @@
-from configsuite_tui.tui import tui
+import pluggy
+
+hookimpl = pluggy.HookimplMarker("configsuite_tui")
+
 
 try:
     from ._version import version as __version__

--- a/configsuite_tui/hookspecs.py
+++ b/configsuite_tui/hookspecs.py
@@ -1,0 +1,12 @@
+import pluggy
+
+hookspec = pluggy.HookspecMarker("configsuite_tui")
+
+
+@hookspec
+def configsuite_tui_schema():
+    """Register ConfigSuite Schema on ConfigSuite-TUI
+    Return dict: {"name": name, "schema": schema}
+    name = string
+    schema = ConfigSuite schema object
+    """

--- a/configsuite_tui/hookspecs.py
+++ b/configsuite_tui/hookspecs.py
@@ -6,7 +6,7 @@ hookspec = pluggy.HookspecMarker("configsuite_tui")
 @hookspec
 def configsuite_tui_schema():
     """Register ConfigSuite Schema on ConfigSuite-TUI
-    Return dict: {"name": name, "schema": schema}
+    Return dict: {name: schema}
     name = string
     schema = ConfigSuite schema object
     """

--- a/configsuite_tui/test_hook.py
+++ b/configsuite_tui/test_hook.py
@@ -1,0 +1,18 @@
+from configsuite import types
+from configsuite import MetaKeys as MK
+import configsuite_tui
+
+
+@configsuite_tui.hookimpl
+def configsuite_tui_schema():
+    name = "test"
+    schema = {
+        MK.Type: types.NamedDict,
+        MK.Content: {
+            "name": {MK.Type: types.String},
+            "hobby": {MK.Type: types.String},
+            "age": {MK.Type: types.Integer},
+        },
+    }
+
+    return {name: schema}

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,3 +2,4 @@ pyyaml==5.4.1
 configsuite==0.6.6
 npyscreen==4.10.5
 fastnumbers==3.1.0
+pluggy==0.13.1

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     packages=["configsuite_tui"],
     use_scm_version={"write_to": "configsuite_tui/_version.py"},
     setup_requires=["setuptools_scm", "setuptools_scm_about"],
-    install_requires=["pyyaml", "npyscreen", "configsuite", "fastnumbers"],
+    install_requires=["pyyaml", "npyscreen", "configsuite", "fastnumbers", "pluggy"],
     python_requires=">=3.6",
 )

--- a/setup.py
+++ b/setup.py
@@ -23,4 +23,5 @@ setup(
     setup_requires=["setuptools_scm", "setuptools_scm_about"],
     install_requires=["pyyaml", "npyscreen", "configsuite", "fastnumbers", "pluggy"],
     python_requires=">=3.6",
+    entry_points={"console_scripts": ["configsuite_tui=configsuite_tui.tui:tui"]},
 )

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -8,7 +8,7 @@ from configsuite_tui.tui import tui
 from configsuite_tui.config import save
 
 
-class TestTui(TestCase):
+class Test_Tui_With_Files(TestCase):
     def setUp(self):
         # Create temporary directory
         self.tmpdir = tempfile.mkdtemp()
@@ -21,12 +21,15 @@ class TestTui(TestCase):
     def test_tui_input_save_return_validate(self):
         with tempfile.NamedTemporaryFile(dir=self.tmpdir) as tmpfile:
             testinput = [
+                curses.KEY_DOWN,
                 "Jane Doe",
                 curses.KEY_DOWN,
                 "Electrician",
                 curses.KEY_DOWN,
                 "35",
-                curses.KEY_DOWN,
+                curses.KEY_UP,
+                curses.KEY_UP,
+                curses.KEY_UP,
                 "^S",
                 curses.ascii.NL,
                 curses.KEY_RIGHT,
@@ -54,10 +57,7 @@ class TestTui(TestCase):
         with tempfile.NamedTemporaryFile(dir=self.tmpdir) as tmpfile:
             save(config, tmpfile.name)
             testinput = [
-                curses.KEY_DOWN,
-                curses.KEY_DOWN,
-                curses.KEY_DOWN,
-                "^L",
+                "^D",
                 curses.ascii.NL,
                 curses.KEY_RIGHT,
                 curses.ascii.NL,
@@ -78,19 +78,39 @@ class TestTui(TestCase):
 
     def test_cancel_forms_and_no_fork(self):
         testinput = [
-            curses.KEY_DOWN,
-            curses.KEY_DOWN,
-            curses.KEY_DOWN,
-            "^L",
+            "^A",
             curses.KEY_DOWN,
             curses.ascii.NL,
             "^S",
             curses.KEY_DOWN,
             curses.ascii.NL,
+            "^D",
+            curses.KEY_DOWN,
+            curses.ascii.NL,
+            curses.KEY_DOWN,
+            curses.KEY_UP,
             "^Q",
         ]
         npyscreen.TEST_SETTINGS["TEST_INPUT"] = testinput
         config, valid = tui()
 
-        self.assertEqual(config, {"age": "", "hobby": "", "name": ""})
+        self.assertEqual(config, {})
+        self.assertFalse(valid)
+
+    def test_load_schema_no_fork(self):
+        testinput = [
+            "^A",
+            curses.ascii.NL,
+            curses.ascii.NL,
+            curses.KEY_DOWN,
+            curses.KEY_DOWN,
+            curses.ascii.NL,
+            curses.KEY_DOWN,
+            curses.KEY_UP,
+            "^Q",
+        ]
+        npyscreen.TEST_SETTINGS["TEST_INPUT"] = testinput
+        config, valid = tui(test=True)
+
+        self.assertEqual(config, {"name": "", "hobby": "", "age": ""})
         self.assertFalse(valid)


### PR DESCRIPTION
Added Pluggy as a plugin manager for schemas.

This changes the program as follows:
- ConfigSuite-TUI starts without a chosen schema, schema has to be loaded from menu
- Validation is much faster than before
- No longer have to click up or down for config to update before saving or quitting

Example of how to create a hook from external library:
```python
#configsuite_tui_hook.py

import configsuite_tui
from configsuite import types
from configsuite import MetaKeys as MK


@configsuite_tui.hookimpl
def configsuite_tui_schema():
    name = "Hook_test"
    schema = {
        MK.Type: types.NamedDict,
        MK.Content: {
            "name": {MK.Type: types.String},
            "hobby": {MK.Type: types.String},
            "age": {MK.Type: types.Integer},
        },
    }

    return {name: schema}

```
```python
#setup.py

from setuptools import setup

setup(
    name="configsuite-tui-hook",
    install_requires="configsuite_tui",
    entry_points={"configsuite_tui": ["hook = configsuite_tui_hook"]},
    py_modules=["configsuite_tui_hook"],
)

```

Install with pip install .
Now a new entry will be available in the schema load menu.

closes #10