### PR TITLE
Add automatic deploy to PyPI workflow

### DIFF
--- a/.github/workflows/pypi-deploy.yml
+++ b/.github/workflows/pypi-deploy.yml
@@ -1,0 +1,15 @@
+name: Publish Python distributions to PyPI
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  deploy:
+    steps:
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_SECRET }}


### PR DESCRIPTION
Added deploy to PyPI as per [https://github.com/marketplace/actions/pypi-publish](url)

Not possible to test without merging and making a release?
Should be ok I guess..

Closes #9 