### PR TITLE
Change to proper symbol for list on open list button

### DIFF
--- a/configsuite_tui/tui.py
+++ b/configsuite_tui/tui.py
@@ -239,10 +239,16 @@ class SchemaForm(CustomFormMultiPage):
                 values=[False, True],
                 value=int(value),
             )
-        elif mk_type in ["list", "dict", "named_dict"]:
+        elif mk_type in ["dict", "named_dict"]:
             self.schemawidgets[index] = self.add_widget_intelligent(
                 CustomCollectionButton,
                 name=name + " {...}",
+                when_pressed_function=self.edit_collection,
+            )
+        elif mk_type == "list":
+            self.schemawidgets[index] = self.add_widget_intelligent(
+                CustomCollectionButton,
+                name=name + " [...]",
                 when_pressed_function=self.edit_collection,
             )
         else:


### PR DESCRIPTION
## Features
- List is now properly rendered with [...] instead of {...}