### PR TITLE
Add cli execution arguments and config file header

### DIFF
--- a/configsuite_tui/__main__.py
+++ b/configsuite_tui/__main__.py
@@ -1,4 +1,21 @@
+import argparse
 from configsuite_tui.tui import tui
 
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(dest="config", type=str, nargs="?", default="")
+    parser.add_argument(
+        "-c", "--config", type=str, default="", help="Path to config file"
+    )
+    parser.add_argument("-s", "--schema", type=str, default="", help="Name of schema")
+
+    args = parser.parse_args()
+    config = args.config
+    schema = args.schema
+
+    tui(config, schema)
+
+
 if __name__ == "__main__":
-    tui()
+    main()

--- a/configsuite_tui/config_tools.py
+++ b/configsuite_tui/config_tools.py
@@ -3,12 +3,20 @@ from configsuite import ConfigSuite
 
 
 def load(filename):
+    with open(filename, "r") as file:
+        first_line = file.readline()
+
     with open(filename) as file:
-        return yaml.full_load(file)
+        schema = None
+        if "!# configsuite-tui" in first_line:
+            next(file)
+            schema = first_line.split("!# configsuite-tui: schema=")[1].strip()
+        return yaml.full_load(file), schema
 
 
-def save(config, filename):
+def save(config, filename, schema):
     with open(filename, "w") as file:
+        file.write("!# configsuite-tui: schema=" + schema + "\n")
         yaml.dump(config, file, sort_keys=False)
 
 

--- a/configsuite_tui/tui.py
+++ b/configsuite_tui/tui.py
@@ -23,7 +23,7 @@ from configsuite_tui import (
 )
 
 
-def tui(**kwargs):
+def tui(config="", schema="", test=False, fork=True):
     # Variables to hold information and states of the TUI
     tui.schema = {}
     tui.schema_name = ""
@@ -43,6 +43,17 @@ def tui(**kwargs):
     pm = get_plugin_manager()
     for s in pm.hook.configsuite_tui_schema():
         tui.schema_list.update(s)
+
+    # Process arguments
+    tui.test = test
+    if schema:
+        tui.schema = tui.schema_list[schema]
+        tui.schema_name = schema
+    if config:
+        tui.config, tmp_schema = load(config)
+        if not tui.schema and tmp_schema:
+            tui.schema = tui.schema_list[tmp_schema]
+            tui.schema_name = tmp_schema
 
     App = Interface()
     if "test" in kwargs and kwargs["test"]:

--- a/configsuite_tui/tui.py
+++ b/configsuite_tui/tui.py
@@ -543,7 +543,7 @@ class SaveConfig(CustomSavePopup):
 
     def on_ok(self, *args, **keywords):
         if self.filename.value:
-            save(tui.config, self.filename.value)
+            save(tui.config, self.filename.value, tui.schema_name)
             tui.config_file = self.filename.value
             custom_notify_wait(
                 title="Saved", message="Configuration saved to: " + tui.config_file
@@ -562,7 +562,7 @@ class LoadConfig(CustomLoadPopup):
 
     def on_ok(self):
         try:
-            tui.config = load(self.filename.value)
+            tui.config = load(self.filename.value)[0]
             tui.config_file = self.filename.value
         except yaml.YAMLError:
             self.error_message = (

--- a/configsuite_tui/tui.py
+++ b/configsuite_tui/tui.py
@@ -39,7 +39,7 @@ def tui(config="", schema="", test=False, fork=True):
     tui.config_index = []
     tui.position = None
 
-    # Get list of pluggy hooks
+    # Get list of registered schemas
     pm = get_plugin_manager()
     for s in pm.hook.configsuite_tui_schema():
         tui.schema_list.update(s)
@@ -55,18 +55,10 @@ def tui(config="", schema="", test=False, fork=True):
             tui.schema = tui.schema_list[tmp_schema]
             tui.schema_name = tmp_schema
 
+    # Run application
     App = Interface()
-    if "test" in kwargs and kwargs["test"]:
-        tui.test = True
-        tui.schema = tui.schema_list["test"]
-        tui.schema_name = list(tui.schema_list.keys())[0]
-        App.run(fork=False)
-    elif "test_fork" in kwargs and kwargs["test_fork"]:
-        tui.test = False
-        App.run(fork=False)
-    else:
-        tui.test = False
-        App.run()
+    App.run(fork=fork)
+
     return tui.config, tui.valid
 
 

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,5 @@ setup(
         "python-dateutil",
     ],
     python_requires=">=3.6",
-    entry_points={"console_scripts": ["configsuite_tui=configsuite_tui.tui:tui"]},
+    entry_points={"console_scripts": ["configsuite_tui=configsuite_tui.__main__:main"]},
 )

--- a/tests/schemas/test_schema_3.py
+++ b/tests/schemas/test_schema_3.py
@@ -1,4 +1,3 @@
-import configsuite
 from configsuite import types
 from configsuite import MetaKeys as MK
 import configsuite_tui

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,7 @@ class TestConfig(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tempdir:
             filepath = tempdir + "/test.yml"
             config = {"name": "Joe Biden", "hobby": "President", "age": 78}
-            save(config, filepath)
-            loaded_config = load(filepath)
+            save(config, filepath, "test")
+            loaded_config, loaded_schema = load(filepath)
             self.assertTrue(validate(loaded_config, self.schema))
+            self.assertEqual(loaded_schema, "test")

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -68,7 +68,7 @@ class Test_Tui_With_Files(TestCase):
                 curses.ascii.NL,
             ]
             npyscreen.TEST_SETTINGS["TEST_INPUT"] = testinput
-            config, valid = tui(test=True)
+            config, valid = tui(schema="test", test=True, fork=False)
 
             self.assertEqual(
                 config,
@@ -121,7 +121,7 @@ class Test_Tui_With_Files(TestCase):
                 curses.ascii.NL,
             ]
             npyscreen.TEST_SETTINGS["TEST_INPUT"] = testinput
-            config, valid = tui(test=True)
+            config, valid = tui(schema="test", test=True, fork=False)
 
             self.assertEqual(
                 config,
@@ -157,7 +157,7 @@ class Test_Tui_With_Files(TestCase):
             curses.ascii.NL,
         ]
         npyscreen.TEST_SETTINGS["TEST_INPUT"] = testinput
-        config, valid = tui()
+        config, valid = tui(fork=False)
 
         self.assertEqual(config, None)
         self.assertFalse(valid)
@@ -181,7 +181,7 @@ class Test_Tui_With_Files(TestCase):
             curses.ascii.NL,
         ]
         npyscreen.TEST_SETTINGS["TEST_INPUT"] = testinput
-        config, valid = tui(test=True)
+        config, valid = tui(test=True, fork=False)
 
         self.assertEqual(
             config,
@@ -216,7 +216,7 @@ class Test_Tui_With_Mocked_Schema(TestCase):
             curses.ascii.NL,
         ]
         npyscreen.TEST_SETTINGS["TEST_INPUT"] = testinput
-        config, valid = tui(test=True)
+        config, valid = tui(schema="test", test=True, fork=False)
 
         self.assertEqual(
             config,
@@ -258,7 +258,7 @@ class Test_Tui_With_Mocked_Schema(TestCase):
             curses.ascii.NL,
         ]
         npyscreen.TEST_SETTINGS["TEST_INPUT"] = testinput
-        config, valid = tui(test=True)
+        config, valid = tui(schema="test", test=True, fork=False)
 
         self.assertEqual(
             config,
@@ -273,8 +273,9 @@ class Test_Tui_With_Mocked_Schema(TestCase):
         self.assertTrue(valid)
 
     @mock.patch("configsuite_tui.tui.get_plugin_manager", return_value=pm)
-    def test_error_blocks_quit(self, mocked_pm):
+    def test_popup_blocks_quit(self, mocked_pm):
         testinput = [
+            "^A",
             "^Q",
             curses.ascii.NL,
             curses.KEY_RIGHT,
@@ -283,7 +284,7 @@ class Test_Tui_With_Mocked_Schema(TestCase):
         npyscreen.TEST_SETTINGS["TEST_INPUT"] = testinput
 
         with self.assertRaises(npyscreen.wgwidget.ExhaustedTestInput):
-            tui(test=True)
+            tui(test=True, fork=False)
 
 
 class Test_Tui_With_Nested_Collections(TestCase):
@@ -339,7 +340,7 @@ class Test_Tui_With_Nested_Collections(TestCase):
             curses.ascii.NL,
         ]
         npyscreen.TEST_SETTINGS["TEST_INPUT"] = testinput
-        config, valid = tui(test_fork=True)
+        config, valid = tui(test=False, fork=False)
 
         self.assertEqual(
             config,

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -104,7 +104,7 @@ class Test_Tui_With_Files(TestCase):
             "last_seen": datetime.datetime(2011, 12, 4, 0, 4, 15),
         }
         with tempfile.NamedTemporaryFile(dir=self.tmpdir) as tmpfile:
-            save(config, tmpfile.name)
+            save(config, tmpfile.name, "test")
             testinput = [
                 "^L",
                 curses.ascii.NL,

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -84,7 +84,8 @@ class Test_Tui_With_Files(TestCase):
             )
             self.assertTrue(valid)
             test_string = (
-                "name: Jane Doe\nhobby: Electrician\nage: 35\nactive: true\nscore: "
+                "!# configsuite-tui: schema=test\n"
+                + "name: Jane Doe\nhobby: Electrician\nage: 35\nactive: true\nscore: "
                 + "45.35\nbirthday: 1999-01-01\nlast_seen: 2011-11-04 00:05:23\n"
             )
             self.assertEqual(


### PR DESCRIPTION
## Features
- Add header to top of config file when saving file with the used schema name.
Schema can also be added manually. Should be formatted as: `!# configsuite-tui: schema=<schema name>`
- Add possibility to pass config and schema from CLI
The use is as follows: `configsuite_tui  -c/--config <config file> -s/--schema <schema name>`
Config can also be written without option: `configsuite_tui <config file>`
If the config file has a schema name header, this will be loaded directly without having to specify schema in the CLI.

closes #37 
closes #38 